### PR TITLE
fix:链接少了X11和vdpau库，导致linux上链接不过

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,7 +386,7 @@ target_link_libraries(cpp_media_server
     ssl crypto
     srtp2 pthread sdptransform
     pthread rt dl z m bz2
-    uv)
+    uv X11 vdpau)
 ENDIF ()
 
 #IF (NATIVE_CLIENT STREQUAL on)


### PR DESCRIPTION
链接少库